### PR TITLE
Add support for nested arrays in query-string generation

### DIFF
--- a/src/RestClient.php
+++ b/src/RestClient.php
@@ -289,11 +289,22 @@ class RestClient implements \Iterator, \ArrayAccess {
 	}
 
 	public function format_query($parameters, $primary='=', $secondary='&'){
-		$query = "";
+		$queryParts = [];
 		foreach($parameters as $key => $value){
-			$pair = array(urlencode($key), urlencode($value));
-			$query .= implode($primary, $pair) . $secondary;
+			if(is_array($value)) { // -- recurse
+				$subParameters = [];
+				foreach($value as $subKey => $subValue) {
+					$newKey                 = $key.'['.$subKey.']';
+					$subParameters[$newKey] = $subValue;
+					$queryParts[]           = $this->format_query($subParameters, $primary, $secondary);
+				}
+			} else {
+				$pair         = array(urlencode($key), urlencode($value));
+				$queryParts[] = implode($primary, $pair);
+			}
 		}
+		$query = implode($secondary, $queryParts);
+
 		return rtrim($query, $secondary);
 	}
 


### PR DESCRIPTION
Allows for more complex data structures. i.e.:

``` php
<?php

$data = [
    'foo' => 'bar',
    'baz' => 'bam',
    'zip' => [
        'fizz',
        'zap' => 'zoo'
    ]
];

$client   = new \Positivezero\RestClient();
$response = $client->get( $url, $data );
```

Will now generate the following querystring:

`foo=bar&baz=bam&zip[0]=fizz&zip[0]=fizz&zip[zap]=zoo`
